### PR TITLE
Allow setting description for a build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   app:
     description: Convox app name
     required: true
+  description:
+    description: Convox build description
+    required: false
 outputs:
   release:
     description: Release ID of the created build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Building"
 export CONVOX_RACK=$INPUT_RACK
-release=$(convox build --app $INPUT_APP --id)
+release=$(convox build --app $INPUT_APP --description "$INPUT_DESCRIPTION" --id)
 if [ -z "$release" ]
 then
   echo "Build failed"


### PR DESCRIPTION
Solving #2 for me, and based on this https://github.com/convox/action-deploy/commit/805c8767c60f371b95fb103863f3df007ee6ba19 this PR change can be used like so:

```
    - name: capture branch
      id: vars
      run: |
        echo ::set-output name=branch::${GITHUB_REF#refs/*/}
        echo ::set-output name=sha_short::$(git rev-parse --short HEAD)
        echo ::set-output name=message::$(git log -1 --pretty=%B)
    - name: production
      uses: digivizer/action-build@description-input
      with:
        rack: production
        app: ${{ github.event.repository.name }}
        description: push digivizer/${{ github.event.repository.name }}:${{ steps.vars.outputs.branch }} ${{ steps.vars.outputs.sha_short }} ${{ steps.vars.outputs.message }}

```