### PR TITLE
chore:migrated deprecated set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,5 +12,5 @@ then
   echo "Build failed"
   exit 1
 fi
-echo ::set-output name=release::$release
+echo "release=$release" >> $GITHUB_OUTPUT
 echo "RELEASE=$release" >> $GITHUB_ENV


### PR DESCRIPTION
This fix with remove the deprecated warning we get while using action-build

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209803387529756